### PR TITLE
Set return type attribute to suppress deprecation warning

### DIFF
--- a/src/Klarna/Rest/Resource.php
+++ b/src/Klarna/Rest/Resource.php
@@ -106,6 +106,7 @@ abstract class Resource extends \ArrayObject
      * 
      * @param array $array Data to be exchanged
      */
+    #[\ReturnTypeWillChange]
     public function exchangeArray($array)
     {
         $id = $this->getId();


### PR DESCRIPTION
Fixes https://github.com/centarro/kco_rest_php/issues/3 but..
This PR breaks PHP 7 compatibility, so there's more work to do here, including preparing tests for PHP 8